### PR TITLE
Fix error for query strings without an equals sign

### DIFF
--- a/src/main/java/valandur/webapi/misc/Util.java
+++ b/src/main/java/valandur/webapi/misc/Util.java
@@ -44,7 +44,7 @@ public class Util {
         String[] splits = query.split("&");
         for (String split : splits) {
             String[] subSplits = split.split("=");
-            map.put(subSplits[0], subSplits[1]);
+            map.put(subSplits[0], subSplits.length == 2 ? subSplits[1] : "");
         }
         return map;
     }


### PR DESCRIPTION
This fixes a crash if someone would pass `&test` instead of `&test=blah` as a query.

Sorry for the two failed PRs ...