### PR TITLE
Update webapi-sponge to vshop 2.2.1

### DIFF
--- a/webapi-sponge/build.gradle
+++ b/webapi-sponge/build.gradle
@@ -36,7 +36,10 @@ repositories {
         url "http://repo.bstats.org/content/repositories/releases/"
     }
     maven {
-        url = "http://repo.aikar.co/nexus/content/groups/aikar/"
+        url "http://repo.aikar.co/nexus/content/groups/aikar/"
+    }
+    maven {
+        url 'https://jitpack.io'
     }
     flatDir {
         dirs "lib"
@@ -87,7 +90,7 @@ dependencies {
     compileOnly name: "Nucleus-1.12.1-S7.1-api"
     compileOnly name: "RedProtect-7.5.5-b130-Universal"
     compileOnly name: "UniversalMarket-1.12.2-v1.3"
-    compileOnly name: "VillagerShops-2.0.1"
+    compileOnly "com.github.DosMike:VillagerShops:development-SNAPSHOT"
     compileOnly name: "WebBooks"
 }
 

--- a/webapi-sponge/src/main/java/valandur/webapi/integration/villagershops/VShopCompareUtils.java
+++ b/webapi-sponge/src/main/java/valandur/webapi/integration/villagershops/VShopCompareUtils.java
@@ -1,7 +1,12 @@
 package valandur.webapi.integration.villagershops;
 
 import com.flowpowered.math.vector.Vector3d;
-import de.dosmike.sponge.vshop.*;
+import de.dosmike.sponge.vshop.menus.InvPrep;
+import de.dosmike.sponge.vshop.shops.NPCguard;
+import de.dosmike.sponge.vshop.shops.StockItem;
+import de.dosmike.sponge.vshop.VillagerShops;
+import de.dosmike.sponge.vshop.Utilities;
+import de.dosmike.sponge.vshop.API;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.EntityType;
 import org.spongepowered.api.text.serializer.TextSerializers;
@@ -83,7 +88,7 @@ class VShopCompareUtils {
                             item.getItem().createStack(),
                             item.getSellPrice(),
                             item.getBuyPrice(),
-                            VillagerShops.getInstance().CurrencyByName(item.getCurrency().getId()),
+                            Utilities.CurrencyByName(item.getCurrency().getId()),
                             item.getMaxStock()));
                 } else if (i >= newS) {
                     inv.removeIndex(i);
@@ -93,7 +98,7 @@ class VShopCompareUtils {
                             item.getItem().createStack(),
                             item.getSellPrice(),
                             item.getBuyPrice(),
-                            VillagerShops.getInstance().CurrencyByName(item.getCurrency().getId()),
+                            Utilities.CurrencyByName(item.getCurrency().getId()),
                             item.getMaxStock()));
                 }
             }

--- a/webapi-sponge/src/main/java/valandur/webapi/integration/villagershops/VShopServlet.java
+++ b/webapi-sponge/src/main/java/valandur/webapi/integration/villagershops/VShopServlet.java
@@ -1,6 +1,11 @@
 package valandur.webapi.integration.villagershops;
 
-import de.dosmike.sponge.vshop.*;
+import de.dosmike.sponge.vshop.menus.InvPrep;
+import de.dosmike.sponge.vshop.shops.NPCguard;
+import de.dosmike.sponge.vshop.shops.StockItem;
+import de.dosmike.sponge.vshop.Utilities;
+import de.dosmike.sponge.vshop.VillagerShops;
+import de.dosmike.sponge.vshop.API;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.spongepowered.api.entity.EntityType;
@@ -35,6 +40,7 @@ public class VShopServlet extends BaseServlet {
             value = "List Shops",
             notes = "Return a list of all shops")
     public Collection<CachedVShop> listShops() {
+
         return WebAPI.runOnMain(() -> API.list().stream().map(CachedVShop::new).collect(Collectors.toList()));
     }
 
@@ -232,7 +238,7 @@ public class VShopServlet extends BaseServlet {
                     req.getItem().createStack(),
                     req.getSellPrice(),
                     req.getBuyPrice(),
-                    VillagerShops.getInstance().CurrencyByName(req.getCurrency().getId()),
+                    Utilities.CurrencyByName(req.getCurrency().getId()),
                     req.getMaxStock()));
 
             return new CachedStockItem(inv.getItem(s), s, npc.get().getIdentifier());
@@ -272,7 +278,7 @@ public class VShopServlet extends BaseServlet {
                         req.getItem().createStack(),
                         req.getSellPrice(),
                         req.getBuyPrice(),
-                        VillagerShops.getInstance().CurrencyByName(req.getCurrency().getId()),
+                        Utilities.CurrencyByName(req.getCurrency().getId()),
                         req.getMaxStock()));
 
                 return new CachedStockItem(inv.getItem(item), item, npc.get().getIdentifier());

--- a/webapi-sponge/src/main/java/valandur/webapi/integration/villagershops/wrapper/CachedVShop.java
+++ b/webapi-sponge/src/main/java/valandur/webapi/integration/villagershops/wrapper/CachedVShop.java
@@ -1,7 +1,7 @@
 package valandur.webapi.integration.villagershops.wrapper;
 
-import de.dosmike.sponge.vshop.InvPrep;
-import de.dosmike.sponge.vshop.NPCguard;
+import de.dosmike.sponge.vshop.menus.InvPrep;
+import de.dosmike.sponge.vshop.shops.NPCguard;
 import de.dosmike.sponge.vshop.VillagerShops;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;


### PR DESCRIPTION
Currently only intended for review.

Once i actually push the 2.2.1 update to villager shops I'll switch the dependency from 'development-SNAPSHOT' to '2.2.1'. Should give you enough time to update the admin panel if you want to (filter are new, stack size is obsolete)